### PR TITLE
Fix: Ignore composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /phpunit.xml
 /phpdox.xml
 cache.properties
+composer.lock


### PR DESCRIPTION
This PR

* [x] ignores `composer.lock`

💁‍♂️ Running

```
$ composer install
```

results in unstaged changes otherwise.