### PR TITLE
Fix: Remove tools directory from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 /.idea
 /bin
 /build
-/tools
 /vendor
 /phpunit.xml
 /phpdox.xml


### PR DESCRIPTION
This PR

* [x] removes the `tools` directory from `.gitignore`