### PR TITLE
Enhancement: Raise error level from 7 to 6

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,2 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.1.1@16bfbd9224698bd738c665f33039fade2a1a3977"/>
+<files psalm-version="4.1.1@16bfbd9224698bd738c665f33039fade2a1a3977">
+  <file src="src/components/stream/Stream.php">
+    <InvalidArgument occurrences="1">
+      <code>$options</code>
+    </InvalidArgument>
+    <InvalidPropertyAssignmentValue occurrences="3">
+      <code>$this-&gt;fp</code>
+      <code>0</code>
+      <code>0</code>
+    </InvalidPropertyAssignmentValue>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     cacheDirectory=".build/psalm"
     errorBaseline="psalm-baseline.xml"
-    errorLevel="7"
+    errorLevel="6"
     findUnusedVariablesAndParams="true"
     resolveFromConfigFile="true"
     strictBinaryOperands="true"


### PR DESCRIPTION
This PR

* [x] raises the error level for `vimeo/psalm` from `6` to `7`
* [x] regenerates the baseline