### PR TITLE
Enhancement: Use ::class pseudo constant

### DIFF
--- a/src/framework/RequestProcessor.php
+++ b/src/framework/RequestProcessor.php
@@ -28,6 +28,7 @@ use Lucille\Request\PostRequest;
 use Lucille\Request\PutRequest;
 use Lucille\Request\PatchRequest;
 use Lucille\Request\DeleteRequest;
+use Lucille\Request\GetRequest;
 
 /**
  * Class RequestProcessor
@@ -124,7 +125,7 @@ class RequestProcessor {
         try {
             $chain = null;
             switch (get_class($request)) {
-                case 'Lucille\Request\GetRequest': {
+                case GetRequest::class: {
                     $chain = $this->getRoutingChain;
                     break;
                 }


### PR DESCRIPTION
This PR

* [x] uses the `::class` pseudo constants instead of using literal `string`s as class names