### PR TITLE
Improve some PHPunit stuffs

### DIFF
--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -29,7 +29,7 @@ class FactoryTest extends TestCase {
     
     private $factory;
     
-    public function setUp(): void {
+    protected function setUp(): void {
         $this->factory = new Factory();
     }
     

--- a/tests/framework/header/HeaderCollectionTest.php
+++ b/tests/framework/header/HeaderCollectionTest.php
@@ -29,7 +29,7 @@ class HeaderCollectionTest extends TestCase {
      */
     public function testCountableReturnsHeaderCountIfNoHeadersAreSet() {
         $collection = new HeaderCollection();
-        $this->assertEquals(0, count($collection));
+        $this->assertCount(0, $collection);
     }
     
     /**
@@ -41,7 +41,7 @@ class HeaderCollectionTest extends TestCase {
         $collection = new HeaderCollection();
         $collection->addHeader(new Header('HTTP_X_HEADER1', 'bar'));
         $collection->addHeader(new Header('HTTP_X_HEADER2', 'foo'));
-        $this->assertEquals(2, count($collection));
+        $this->assertCount(2, $collection);
     }
     
     /**

--- a/tests/framework/response/GenericResponseTest.php
+++ b/tests/framework/response/GenericResponseTest.php
@@ -28,7 +28,7 @@ class GenericResponseTest extends TestCase {
         $res = new TestResponse();
         
         $this->assertInstanceOf(HeaderCollection::class, $res->getHeaderCollection());
-        $this->assertEquals(0, count($res->getHeaderCollection()));
+        $this->assertCount(0, $res->getHeaderCollection());
     }
     
     


### PR DESCRIPTION
# Changed log

- According to the official [PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html?highlight=fixtures#fixtures), it should be `protected function setUp(): void`.
- Using the `assertCount` to assert the expected count is same as result.