### PR TITLE
Fix: Run static code analysis on lowest supported PHP version

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -112,7 +112,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "7.2"
 
         dependencies:
           - "highest"


### PR DESCRIPTION
This pull request

* [x] runs the static code analysis on the lowest supported PHP version