### PR TITLE
Using the assertSame to make assert equals strict

### DIFF
--- a/tests/DirectoryTest.php
+++ b/tests/DirectoryTest.php
@@ -27,7 +27,7 @@ class DirectoryTest extends TestCase {
      */
     public function testReturnsInitialDirectoryPathAsString() {
         $dir = new Directory('/tmp');
-        $this->assertEquals('/tmp', $dir->asString());
+        $this->assertSame('/tmp', $dir->asString());
     }
     
     /**

--- a/tests/FilenameTest.php
+++ b/tests/FilenameTest.php
@@ -26,7 +26,7 @@ class FilenameTest extends TestCase {
      */
     public function testReturnsInitialFilenameAsString() {
         $filename = new Filename(TEST_FILE);
-        $this->assertEquals(TEST_FILE, $filename->asString());
+        $this->assertSame(TEST_FILE, $filename->asString());
     }
     
     /**

--- a/tests/components/xmlcontent/GenericXmlContentTest.php
+++ b/tests/components/xmlcontent/GenericXmlContentTest.php
@@ -55,7 +55,7 @@ class GenericXmlContentTest extends TestCase {
         $doc = new TestXmlContent();
         $doc->loadDocument($dom);
 
-        $this->assertEquals($dom, $doc->getContentDom());
+        $this->assertSame($dom, $doc->getContentDom());
     }
     
     /**
@@ -88,7 +88,7 @@ class GenericXmlContentTest extends TestCase {
         $doc = new TestXmlContent();
         $doc->loadDocument($dom);
 
-        $this->assertEquals($dom, $doc->getContentDom());
+        $this->assertSame($dom, $doc->getContentDom());
     }
     
     /**
@@ -148,7 +148,7 @@ class GenericXmlContentTest extends TestCase {
         $nodeList = $doc->query(new XPathQuery("//*[@id='20']"));
         
         $this->assertInstanceOf(\DOMNodeList::class, $nodeList);
-        $this->assertEquals(2, $nodeList->length);
+        $this->assertSame(2, $nodeList->length);
     }
     
     /**
@@ -210,7 +210,7 @@ class GenericXmlContentTest extends TestCase {
         $xp = $doc->getContentXP();
         
         $this->assertInstanceOf(\DOMXPath::class, $xp);
-        $this->assertEquals('demo', $xp->query("//doc[@id='10']/@label")->item(0)->nodeValue);
+        $this->assertSame('demo', $xp->query("//doc[@id='10']/@label")->item(0)->nodeValue);
     }
 
     /**

--- a/tests/components/xmlcontent/XpathQueryTest.php
+++ b/tests/components/xmlcontent/XpathQueryTest.php
@@ -17,7 +17,7 @@ class XpathQueryTest extends TestCase {
      */
     public function testReturnsInitialXpathQueryString() {
         $xp = new XPathQuery('/root/@label');
-        $this->assertEquals('/root/@label', $xp->asString());
+        $this->assertSame('/root/@label', $xp->asString());
     }
     
 }

--- a/tests/components/xmlcontent/exceptions/LoadingXmlFailedException.php
+++ b/tests/components/xmlcontent/exceptions/LoadingXmlFailedException.php
@@ -31,7 +31,7 @@ class LoadingXmlFailedException extends TestCase {
         try {
             throw new LoadingXmlFileFailedException(new Filename(TEST_FILE));
         } catch (LoadingXmlFileFailedException $e) {
-            $this->assertEquals(TEST_FILE, $e->getFilename()->asString());
+            $this->assertSame(TEST_FILE, $e->getFilename()->asString());
         }
     }
     

--- a/tests/components/xmlcontent/exceptions/XmlTargetIdNotFoundExceptionTest.php
+++ b/tests/components/xmlcontent/exceptions/XmlTargetIdNotFoundExceptionTest.php
@@ -35,7 +35,7 @@ class XmlTargetIdNotFoundExceptionTest extends TestCase {
         try {
             throw new XmlTargetIdNotFoundException('node1');
         } catch (XmlTargetIdNotFoundException $e) {
-            $this->assertEquals('node1', $e->getTargetId());
+            $this->assertSame('node1', $e->getTargetId());
         }
     }
     

--- a/tests/components/xmlcontent/exceptions/XmlTargetIdNotUniqueExceptionTest.php
+++ b/tests/components/xmlcontent/exceptions/XmlTargetIdNotUniqueExceptionTest.php
@@ -35,7 +35,7 @@ class XmlTargetIdNotUniqueExceptionTest extends TestCase {
         try {
             throw new XmlTargetIdNotUniqueException('node2');
         } catch (XmlTargetIdNotUniqueException $e) {
-            $this->assertEquals('node2', $e->getTargetId());
+            $this->assertSame('node2', $e->getTargetId());
         }
     }
     

--- a/tests/components/xmlcontent/xhtml/XhtmlContentTest.php
+++ b/tests/components/xmlcontent/xhtml/XhtmlContentTest.php
@@ -20,7 +20,7 @@ class XhtmlContentTest extends TestCase {
         $xhtml1 = new XhtmlContent(new Filename(__DIR__.'/data/test.xhtml'));
         
         $node = $xhtml1->getContentXP()->query('//html:p/text()')->item(0);
-        $this->assertEquals('test', $node->nodeValue);
+        $this->assertSame('test', $node->nodeValue);
     }
     
     /**
@@ -36,7 +36,7 @@ class XhtmlContentTest extends TestCase {
         $xhtml1->loadDocument($dom);
         
         $node = $xhtml1->getContentXP()->query('//html:p/text()')->item(0);
-        $this->assertEquals('test', $node->nodeValue);
+        $this->assertSame('test', $node->nodeValue);
     }
     
     /**

--- a/tests/components/xsl/exceptions/ImportingXslStylesheetFailedExceptionTest.php
+++ b/tests/components/xsl/exceptions/ImportingXslStylesheetFailedExceptionTest.php
@@ -22,7 +22,7 @@ class ImportingXslStylesheetFailedExceptionTest extends TestCase {
         try {
             throw new ImportingXslStylesheetFailedException($xslFile);
         } catch (ImportingXslStylesheetFailedException $e) {
-            $this->assertEquals($xslFile, $e->getStylesheetFilename());
+            $this->assertSame($xslFile, $e->getStylesheetFilename());
         }
     }
     

--- a/tests/components/xsl/exceptions/LoadingXslStylesheetFailedExceptionTest.php
+++ b/tests/components/xsl/exceptions/LoadingXslStylesheetFailedExceptionTest.php
@@ -22,7 +22,7 @@ class LoadingXslStylesheetFailedExceptionTest extends TestCase {
         try {
             throw new LoadingXslStylesheetFailedException($xslFile);
         } catch (LoadingXslStylesheetFailedException $e) {
-            $this->assertEquals($xslFile, $e->getStylesheetFilename());
+            $this->assertSame($xslFile, $e->getStylesheetFilename());
         }
     }
     

--- a/tests/framework/RequestProcessor/RequestProcessorTest.php
+++ b/tests/framework/RequestProcessor/RequestProcessorTest.php
@@ -55,7 +55,7 @@ class RequestProcessorTest extends TestCase {
         $chain = new GetRoutingChain();
         $proc->addRoutingChain($chain);
         
-        $this->assertEquals($chain, $this->getPrivateClassProperty($proc, 'getRoutingChain'));
+        $this->assertSame($chain, $this->getPrivateClassProperty($proc, 'getRoutingChain'));
     }
 
     /**
@@ -67,7 +67,7 @@ class RequestProcessorTest extends TestCase {
         $chain = new PostRoutingChain();
         $proc->addRoutingChain($chain);
 
-        $this->assertEquals($chain, $this->getPrivateClassProperty($proc, 'postRoutingChain'));
+        $this->assertSame($chain, $this->getPrivateClassProperty($proc, 'postRoutingChain'));
     }
 
     /**
@@ -79,7 +79,7 @@ class RequestProcessorTest extends TestCase {
         $chain = new PutRoutingChain();
         $proc->addRoutingChain($chain);
         
-        $this->assertEquals($chain, $this->getPrivateClassProperty($proc, 'putRoutingChain'));
+        $this->assertSame($chain, $this->getPrivateClassProperty($proc, 'putRoutingChain'));
     }
 
     /**
@@ -91,7 +91,7 @@ class RequestProcessorTest extends TestCase {
         $chain = new PatchRoutingChain();
         $proc->addRoutingChain($chain);
 
-        $this->assertEquals($chain, $this->getPrivateClassProperty($proc, 'patchRoutingChain'));
+        $this->assertSame($chain, $this->getPrivateClassProperty($proc, 'patchRoutingChain'));
     }
 
     /**
@@ -103,7 +103,7 @@ class RequestProcessorTest extends TestCase {
         $chain = new DeleteRoutingChain();
         $proc->addRoutingChain($chain);
 
-        $this->assertEquals($chain, $this->getPrivateClassProperty($proc, 'deleteRoutingChain'));
+        $this->assertSame($chain, $this->getPrivateClassProperty($proc, 'deleteRoutingChain'));
     }
 
     /**
@@ -115,7 +115,7 @@ class RequestProcessorTest extends TestCase {
         $chain = new ResultRoutingChain();
         $proc->addRoutingChain($chain);
 
-        $this->assertEquals($chain, $this->getPrivateClassProperty($proc, 'resultRoutingChain'));
+        $this->assertSame($chain, $this->getPrivateClassProperty($proc, 'resultRoutingChain'));
     }
     
     /**

--- a/tests/framework/exceptions/DirectoryNotFoundExceptionTest.php
+++ b/tests/framework/exceptions/DirectoryNotFoundExceptionTest.php
@@ -20,7 +20,7 @@ class DirectoryNotFoundExceptionTest extends TestCase {
         try {
             throw new DirectoryNotFoundException('/tmp');
         } catch (DirectoryNotFoundException $e) {
-            $this->assertEquals('/tmp', $e->getPath());
+            $this->assertSame('/tmp', $e->getPath());
         }
     }
     

--- a/tests/framework/exceptions/FileNotFoundExceptionTest.php
+++ b/tests/framework/exceptions/FileNotFoundExceptionTest.php
@@ -19,7 +19,7 @@ class FileNotFoundExceptionTest extends TestCase {
         try {
             throw new FileNotFoundException('/tmp/foo.log');
         } catch (FileNotFoundException $e) {
-            $this->assertEquals('/tmp/foo.log', $e->getFilename());
+            $this->assertSame('/tmp/foo.log', $e->getFilename());
         }
     }
     

--- a/tests/framework/exceptions/HeaderNotFoundExceptionTest.php
+++ b/tests/framework/exceptions/HeaderNotFoundExceptionTest.php
@@ -19,7 +19,7 @@ class HeaderNotFoundExceptionTest extends TestCase {
         try {
             throw new HeaderNotFoundException('HTTP_X_API');
         } catch (HeaderNotFoundException $e) {
-            $this->assertEquals('HTTP_X_API', $e->getHeaderName());
+            $this->assertSame('HTTP_X_API', $e->getHeaderName());
         }
     }
     

--- a/tests/framework/exceptions/LucilleExceptionTest.php
+++ b/tests/framework/exceptions/LucilleExceptionTest.php
@@ -36,7 +36,7 @@ class LucilleExceptionTest extends TestCase {
         } catch (LucilleException $e) {
             $full = substr($e->getFullMessage(), 0, 56);
             $expected = "Lucille Framework Error (12) 'generic exception' at line";
-            $this->assertEquals($expected, $full);
+            $this->assertSame($expected, $full);
         }
     }
     

--- a/tests/framework/exceptions/RequestParameterCollectionNotFoundExceptionTest.php
+++ b/tests/framework/exceptions/RequestParameterCollectionNotFoundExceptionTest.php
@@ -19,7 +19,7 @@ class RequestParameterCollectionNotFoundExceptionTest extends TestCase {
         try {
             throw new RequestParameterCollectionNotFoundException('list01');
         } catch (RequestParameterCollectionNotFoundException $e) {
-            $this->assertEquals('list01', $e->getParameterCollectionName());
+            $this->assertSame('list01', $e->getParameterCollectionName());
         }
     }
     

--- a/tests/framework/exceptions/RequestParameterNotFoundExceptionTest.php
+++ b/tests/framework/exceptions/RequestParameterNotFoundExceptionTest.php
@@ -19,7 +19,7 @@ class RequestParameterNotFoundExceptionTest extends TestCase {
         try {
             throw new RequestParameterNotFoundException('param1');
         } catch (RequestParameterNotFoundException $e) {
-            $this->assertEquals('param1', $e->getParameterName());
+            $this->assertSame('param1', $e->getParameterName());
         }
     }
     

--- a/tests/framework/header/HeaderCollectionTest.php
+++ b/tests/framework/header/HeaderCollectionTest.php
@@ -21,7 +21,7 @@ class HeaderCollectionTest extends TestCase {
         $header = new Header('HTTP_X_HEADER1', 'bar123');
         $collection = new HeaderCollection();
         $collection->addHeader($header);
-        $this->assertEquals($header, $collection->getHeader('HTTP_X_HEADER1'));
+        $this->assertSame($header, $collection->getHeader('HTTP_X_HEADER1'));
     }
 
     /**
@@ -84,11 +84,11 @@ class HeaderCollectionTest extends TestCase {
         $header1 = $collection->getHeader('HTTP_X_HEADER1');
         $header2 = $collection->getHeader('HTTP_X_HEADER2');
         
-        $this->assertEquals('HTTP_X_HEADER1', $header1->getName());
-        $this->assertEquals('foo', $header1->getValue());
+        $this->assertSame('HTTP_X_HEADER1', $header1->getName());
+        $this->assertSame('foo', $header1->getValue());
         
-        $this->assertEquals('HTTP_X_HEADER2', $header2->getName());
-        $this->assertEquals('bar', $header2->getValue());
+        $this->assertSame('HTTP_X_HEADER2', $header2->getName());
+        $this->assertSame('bar', $header2->getValue());
     }
 
 }

--- a/tests/framework/header/HeaderTest.php
+++ b/tests/framework/header/HeaderTest.php
@@ -16,7 +16,7 @@ class HeaderTest extends TestCase {
      */
     public function testReturnsHeaderName() {
         $header = new Header('header_name', 'demo123');
-        $this->assertEquals('header_name', $header->getName());
+        $this->assertSame('header_name', $header->getName());
     }
     
     /**
@@ -25,7 +25,7 @@ class HeaderTest extends TestCase {
      */
     public function testReturnsHeaderValue() {
         $header = new Header('header_name', 'demo123');
-        $this->assertEquals('demo123', $header->getValue());
+        $this->assertSame('demo123', $header->getValue());
     }
 
     /**
@@ -36,7 +36,7 @@ class HeaderTest extends TestCase {
      */
     public function testReturnsHeaderAsString() {
         $header = new Header('header_name', 'demo123');
-        $this->assertEquals('header_name: demo123', $header->asString());
+        $this->assertSame('header_name: demo123', $header->asString());
     }
     
 }

--- a/tests/framework/request/DeleteRequestTest.php
+++ b/tests/framework/request/DeleteRequestTest.php
@@ -38,9 +38,9 @@ class DeleteRequestTest extends TestCase {
     public function testPostRequest() {
         $request = $this->buildDeleteRequest();
         
-        $this->assertEquals('/demo', $request->getUri()->asString());
-        $this->assertEquals('h1: v1', $request->getHeaderCollection()->getHeader('h1')->asString());
-        $this->assertEquals('value1', $request->getParameterCollection()->getParam('param1')->asString());
+        $this->assertSame('/demo', $request->getUri()->asString());
+        $this->assertSame('h1: v1', $request->getHeaderCollection()->getHeader('h1')->asString());
+        $this->assertSame('value1', $request->getParameterCollection()->getParam('param1')->asString());
     }
     
     /**
@@ -58,7 +58,7 @@ class DeleteRequestTest extends TestCase {
     public function testGetRawRequestBody() {
         $request = $this->buildDeleteRequest();
         
-        $this->assertEquals('foo bar', $request->getBody()->asString());
+        $this->assertSame('foo bar', $request->getBody()->asString());
     }
     
     private function buildDeleteRequest(): DeleteRequest {

--- a/tests/framework/request/GetRequestTest.php
+++ b/tests/framework/request/GetRequestTest.php
@@ -51,9 +51,9 @@ class GetRequestTest extends TestCase {
         
         $request = new GetRequest($uri, $headerCollection, $parameterCollection);
         
-        $this->assertEquals('/demo', $request->getUri()->asString());
-        $this->assertEquals('h1: v1', $request->getHeaderCollection()->getHeader('h1')->asString());
-        $this->assertEquals('value1', $request->getParameterCollection()->getParam('param1')->asString());
+        $this->assertSame('/demo', $request->getUri()->asString());
+        $this->assertSame('h1: v1', $request->getHeaderCollection()->getHeader('h1')->asString());
+        $this->assertSame('value1', $request->getParameterCollection()->getParam('param1')->asString());
     }
     
 }

--- a/tests/framework/request/PatchRequestTest.php
+++ b/tests/framework/request/PatchRequestTest.php
@@ -38,9 +38,9 @@ class PatchRequestTest extends TestCase {
     public function testPostRequest() {
         $request = $this->buildPatchRequest();
         
-        $this->assertEquals('/demo', $request->getUri()->asString());
-        $this->assertEquals('h1: v1', $request->getHeaderCollection()->getHeader('h1')->asString());
-        $this->assertEquals('value1', $request->getParameterCollection()->getParam('param1')->asString());
+        $this->assertSame('/demo', $request->getUri()->asString());
+        $this->assertSame('h1: v1', $request->getHeaderCollection()->getHeader('h1')->asString());
+        $this->assertSame('value1', $request->getParameterCollection()->getParam('param1')->asString());
     }
     
     /**
@@ -58,7 +58,7 @@ class PatchRequestTest extends TestCase {
     public function testGetRawRequestBody() {
         $request = $this->buildPatchRequest();
         
-        $this->assertEquals('foo bar', $request->getBody()->asString());
+        $this->assertSame('foo bar', $request->getBody()->asString());
     }
     
     private function buildPatchRequest(): PatchRequest {

--- a/tests/framework/request/PostRequestTest.php
+++ b/tests/framework/request/PostRequestTest.php
@@ -38,9 +38,9 @@ class PostRequestTest extends TestCase {
     public function testPostRequest() {
         $request = $this->buildPostRequest();
         
-        $this->assertEquals('/demo', $request->getUri()->asString());
-        $this->assertEquals('h1: v1', $request->getHeaderCollection()->getHeader('h1')->asString());
-        $this->assertEquals('value1', $request->getParameterCollection()->getParam('param1')->asString());
+        $this->assertSame('/demo', $request->getUri()->asString());
+        $this->assertSame('h1: v1', $request->getHeaderCollection()->getHeader('h1')->asString());
+        $this->assertSame('value1', $request->getParameterCollection()->getParam('param1')->asString());
     }
     
     /**
@@ -58,7 +58,7 @@ class PostRequestTest extends TestCase {
     public function testGetRawRequestBody() {
         $request = $this->buildPostRequest();
         
-        $this->assertEquals('foo bar', $request->getBody()->asString());
+        $this->assertSame('foo bar', $request->getBody()->asString());
     }
     
     private function buildPostRequest(): PostRequest {

--- a/tests/framework/request/PutRequestTest.php
+++ b/tests/framework/request/PutRequestTest.php
@@ -38,9 +38,9 @@ class PutRequestTest extends TestCase {
     public function testPostRequest() {
         $request = $this->buildPutRequest();
         
-        $this->assertEquals('/demo', $request->getUri()->asString());
-        $this->assertEquals('h1: v1', $request->getHeaderCollection()->getHeader('h1')->asString());
-        $this->assertEquals('value1', $request->getParameterCollection()->getParam('param1')->asString());
+        $this->assertSame('/demo', $request->getUri()->asString());
+        $this->assertSame('h1: v1', $request->getHeaderCollection()->getHeader('h1')->asString());
+        $this->assertSame('value1', $request->getParameterCollection()->getParam('param1')->asString());
     }
     
     /**
@@ -58,7 +58,7 @@ class PutRequestTest extends TestCase {
     public function testGetRawRequestBody() {
         $request = $this->buildPutRequest();
         
-        $this->assertEquals('foo bar', $request->getBody()->asString());
+        $this->assertSame('foo bar', $request->getBody()->asString());
     }
     
     private function buildPutRequest(): PutRequest {

--- a/tests/framework/request/RequestTest.php
+++ b/tests/framework/request/RequestTest.php
@@ -48,9 +48,9 @@ class RequestTest extends TestCase {
         $this->assertInstanceOf(StringRequestParameter::class, $request->getParam('param2'));
         $this->assertInstanceOf(StringRequestParameter::class, $request->getParam('param3'));
 
-        $this->assertEquals('foo', $request->getParam('param1')->asString());
-        $this->assertEquals('123', $request->getParam('param2')->asString());
-        $this->assertEquals('baz', $request->getParam('param3')->asString());
+        $this->assertSame('foo', $request->getParam('param1')->asString());
+        $this->assertSame('123', $request->getParam('param2')->asString());
+        $this->assertSame('baz', $request->getParam('param3')->asString());
     }
 
     /**

--- a/tests/framework/request/body/EmptyRequestBodyTest.php
+++ b/tests/framework/request/body/EmptyRequestBodyTest.php
@@ -15,7 +15,7 @@ class EmptyRequestBodyTest extends TestCase {
      */
     public function testReturnsInitialContent() {
         $body = new EmptyRequestBody();
-        $this->assertEquals('', $body->asString());
+        $this->assertSame('', $body->asString());
     }
     
 }

--- a/tests/framework/request/body/RawRequestBodyTest.php
+++ b/tests/framework/request/body/RawRequestBodyTest.php
@@ -17,7 +17,7 @@ class RawRequestBodyTest extends TestCase {
     public function testReturnsInitialContent() {
         $str = "test string\ndemo=foo";
         $body = new RawRequestBody($str);
-        $this->assertEquals($str, $body->asString());
+        $this->assertSame($str, $body->asString());
     }
     
 }

--- a/tests/framework/request/body/RequestBodyFactoryTest.php
+++ b/tests/framework/request/body/RequestBodyFactoryTest.php
@@ -28,7 +28,7 @@ class RequestBodyFactoryTest extends TestCase {
     public function testFromStreamReturnsRawRequestBody() {
         $body = RequestBodyFactory::fromStream(__DIR__.'/fixtures/body.txt');
         $this->assertInstanceOf(RawRequestBody::class, $body);
-        $this->assertEquals("demo=foo\nbar=123\n", $body->asString());
+        $this->assertSame("demo=foo\nbar=123\n", $body->asString());
     }
     
 }

--- a/tests/framework/request/parameter/StringRequestParameterTest.php
+++ b/tests/framework/request/parameter/StringRequestParameterTest.php
@@ -19,7 +19,7 @@ class StringRequestParameterTest extends TestCase {
      */
     public function testReturnsInitialParameterName() {
         $param = new StringRequestParameter(new StringRequestParameterName('param1'), 'bar');
-        $this->assertEquals('param1', $param->getName()->asString());
+        $this->assertSame('param1', $param->getName()->asString());
     }
     
     /**
@@ -29,7 +29,7 @@ class StringRequestParameterTest extends TestCase {
      */
     public function testReturnsInitialValueAsString() {
         $param = new StringRequestParameter(new StringRequestParameterName('test'), '1000');
-        $this->assertEquals('1000', $param->asString());
+        $this->assertSame('1000', $param->asString());
         $this->assertIsString($param->asString());
     }
 
@@ -40,7 +40,7 @@ class StringRequestParameterTest extends TestCase {
      */
     public function testReturnsInitialValueAsInt() {
         $param = new StringRequestParameter(new StringRequestParameterName('test'), '1000');
-        $this->assertEquals(1000, $param->asInt());
+        $this->assertSame(1000, $param->asInt());
         $this->assertIsInt($param->asInt());
     }
 
@@ -51,7 +51,7 @@ class StringRequestParameterTest extends TestCase {
      */
     public function testReturnsInitialValueAsFloat() {
         $param = new StringRequestParameter(new StringRequestParameterName('test'), '12.7');
-        $this->assertEquals(12.7, $param->asFloat());
+        $this->assertSame(12.7, $param->asFloat());
         $this->assertIsFloat($param->asFloat());
     }
         

--- a/tests/framework/request/parameter/name/StringRequestParameterNameTest.php
+++ b/tests/framework/request/parameter/name/StringRequestParameterNameTest.php
@@ -19,7 +19,7 @@ class StringRequestParameterNameTest extends TestCase {
      */
     public function testGetValueReturnsInitialParameterNameTrimmed() {
         $param = new StringRequestParameter(new StringRequestParameterName('    paramname             '), 'bar');
-        $this->assertEquals('paramname', $param->getName()->asString());
+        $this->assertSame('paramname', $param->getName()->asString());
         $this->assertIsString($param->getName()->asString());
     }
     

--- a/tests/framework/request/uri/UriPartTest.php
+++ b/tests/framework/request/uri/UriPartTest.php
@@ -16,7 +16,7 @@ class UriPartTest extends TestCase {
      */
     public function testReturnsInitialUriPartAsString() {
         $part = new UriPart('demo');
-        $this->assertEquals('demo', $part->asString());
+        $this->assertSame('demo', $part->asString());
     }
     
 }

--- a/tests/framework/request/uri/UriRegExTest.php
+++ b/tests/framework/request/uri/UriRegExTest.php
@@ -16,7 +16,7 @@ class UriRegExTest extends TestCase {
      */
     public function testReturnsInitialRegexPattern() {
         $regex = new UriRegEx('#(.*)#');
-        $this->assertEquals('#(.*)#', $regex->asString());
+        $this->assertSame('#(.*)#', $regex->asString());
     }
     
 }

--- a/tests/framework/request/uri/UriTest.php
+++ b/tests/framework/request/uri/UriTest.php
@@ -18,7 +18,7 @@ class UriTest extends TestCase {
      */
     public function testReturnsInitialUri() {
         $uri = new Uri('/foo/bar/1234');
-        $this->assertEquals('/foo/bar/1234', $uri->asString());
+        $this->assertSame('/foo/bar/1234', $uri->asString());
     }
     
     /**
@@ -27,7 +27,7 @@ class UriTest extends TestCase {
      */
     public function testReturnsInitialUriAsPath() {
         $uri = new Uri('/foo/bar/1234/test.xml?test=123#foo');
-        $this->assertEquals('/foo/bar/1234/test.xml', $uri->asString());
+        $this->assertSame('/foo/bar/1234/test.xml', $uri->asString());
     }
     
     /**
@@ -37,7 +37,7 @@ class UriTest extends TestCase {
     public function testReturnsOriginUri() {
         $x = '/foo/bar/1234/test.xml?test=123#foo';
         $uri = new Uri($x);
-        $this->assertEquals($x, $uri->originUriAsString());
+        $this->assertSame($x, $uri->originUriAsString());
     }
     
     /**
@@ -110,9 +110,9 @@ class UriTest extends TestCase {
      */
     public function testReturnsUriPartByIndex() {
         $uri = new Uri('/document/demo/123');
-        $this->assertEquals('document', $uri->getPart(0)->asString());
-        $this->assertEquals('demo', $uri->getPart(1)->asString());
-        $this->assertEquals('123', $uri->getPart(2)->asString());
+        $this->assertSame('document', $uri->getPart(0)->asString());
+        $this->assertSame('demo', $uri->getPart(1)->asString());
+        $this->assertSame('123', $uri->getPart(2)->asString());
     }
     
     /**
@@ -127,7 +127,7 @@ class UriTest extends TestCase {
         $this->expectException(UriPartIndexOutOfBoundsException::class);
         
         $uri = new Uri('/document/demo/123');
-        $this->assertEquals('document', $uri->getPart(-2)->asString());
+        $this->assertSame('document', $uri->getPart(-2)->asString());
     }
     
     /**

--- a/tests/framework/response/GenericResponseTest.php
+++ b/tests/framework/response/GenericResponseTest.php
@@ -41,7 +41,7 @@ class GenericResponseTest extends TestCase {
         $res = new TestResponse();
         $res->setResponseCode(340);
         
-        $this->assertEquals(340, $res->getResponseCode());
+        $this->assertSame(340, $res->getResponseCode());
     }
 
     /**

--- a/tests/stream/StreamNameTest.php
+++ b/tests/stream/StreamNameTest.php
@@ -23,7 +23,7 @@ class StreamNameTest extends TestCase {
      */
     public function testReturnsInitialStreamName() {
         $streamName = new StreamName('test');
-        $this->assertEquals('test', $streamName->asString());
+        $this->assertSame('test', $streamName->asString());
     }
     
 }

--- a/tests/stream/StreamTest.php
+++ b/tests/stream/StreamTest.php
@@ -109,7 +109,7 @@ class StreamTest extends TestCase {
      */
     public function testGetRegisteredPathReturnsSchemePathString() {
         Stream::registerStream(new StreamName('templates'), new Directory(__DIR__.'/data'));
-        $this->assertEquals(__DIR__.'/data', Stream::getRegisteredPath(new StreamName('templates')));
+        $this->assertSame(__DIR__.'/data', Stream::getRegisteredPath(new StreamName('templates')));
     }
     
     /**
@@ -138,7 +138,7 @@ class StreamTest extends TestCase {
     public function testTranslateReturnsFullPath() {
         Stream::unregisterStream(new StreamName('templates'));
         Stream::registerStream(new StreamName('templates'), new Directory(__DIR__.'/data'));
-        $this->assertEquals(__DIR__.'/data/demo/1.xsl', Stream::translate('templates://demo/1.xsl'));
+        $this->assertSame(__DIR__.'/data/demo/1.xsl', Stream::translate('templates://demo/1.xsl'));
     }
     
     /**
@@ -153,7 +153,7 @@ class StreamTest extends TestCase {
     public function testTranslateRootDirectoryReturnsPath() {
         Stream::unregisterStream(new StreamName('templates'));
         Stream::registerStream(new StreamName('templates'), new Directory(__DIR__.'/data'));
-        $this->assertEquals(__DIR__.'/data/1.xsl', Stream::translate('templates:///1.xsl'));
+        $this->assertSame(__DIR__.'/data/1.xsl', Stream::translate('templates:///1.xsl'));
     }
     
     /**
@@ -167,7 +167,7 @@ class StreamTest extends TestCase {
      */
     public function testTranslateUnregisteredStreamReturnsInitialPath() {
         Stream::unregisterStream(new StreamName('templates'));
-        $this->assertEquals('templates://demo/1.xsl', Stream::translate('templates://demo/1.xsl'));
+        $this->assertSame('templates://demo/1.xsl', Stream::translate('templates://demo/1.xsl'));
     }
     
     /**
@@ -192,7 +192,7 @@ class StreamTest extends TestCase {
         
         $handle = fopen('templates://test.txt', 'r');
         $data = fread($handle, 100);
-        $this->assertEquals("123\n", $data);
+        $this->assertSame("123\n", $data);
     }
     
 }

--- a/tests/stream/exceptions/CannotRegisterStreamExceptionTest.php
+++ b/tests/stream/exceptions/CannotRegisterStreamExceptionTest.php
@@ -21,7 +21,7 @@ class CannotRegisterStreamExceptionTest extends TestCase {
         try {
             throw new CannotRegisterStreamException(new StreamName('templates'));
         } catch (CannotRegisterStreamException $e) {
-            $this->assertEquals('templates', $e->getProtocolName()->asString());
+            $this->assertSame('templates', $e->getProtocolName()->asString());
         }
     }
     

--- a/tests/stream/exceptions/CannotUnregisterStreamExceptionTest.php
+++ b/tests/stream/exceptions/CannotUnregisterStreamExceptionTest.php
@@ -21,7 +21,7 @@ class CannotUnregisterStreamExceptionTest extends TestCase {
         try {
             throw new CannotUnregisterStreamException(new StreamName('templates'));
         } catch (CannotUnregisterStreamException $e) {
-            $this->assertEquals('templates', $e->getProtocolName()->asString());
+            $this->assertSame('templates', $e->getProtocolName()->asString());
         }
     }
     

--- a/tests/stream/exceptions/StreamAlreadyRegisteredExceptionTest.php
+++ b/tests/stream/exceptions/StreamAlreadyRegisteredExceptionTest.php
@@ -21,7 +21,7 @@ class StreamAlreadyRegisteredExceptionTest extends TestCase {
         try {
             throw new StreamAlreadyRegisteredException(new StreamName('templates'));
         } catch (StreamAlreadyRegisteredException $e) {
-            $this->assertEquals('templates', $e->getProtocolName()->asString());
+            $this->assertSame('templates', $e->getProtocolName()->asString());
         }
     }
     

--- a/tests/stream/exceptions/StreamNotRegisteredExceptionTest.php
+++ b/tests/stream/exceptions/StreamNotRegisteredExceptionTest.php
@@ -21,7 +21,7 @@ class StreamNotRegisteredExceptionTest extends TestCase {
         try {
             throw new StreamNotRegisteredException(new StreamName('templates'));
         } catch (StreamNotRegisteredException $e) {
-            $this->assertEquals('templates', $e->getProtocolName()->asString());
+            $this->assertSame('templates', $e->getProtocolName()->asString());
         }
     }
     


### PR DESCRIPTION
# Changed log

- Replacing the `assertEquals` with `assertSame` to make assert equals strict.